### PR TITLE
Añadir archivo con nombres de los integrantes del grupo

### DIFF
--- a/Integrantes.txt
+++ b/Integrantes.txt
@@ -1,0 +1,2 @@
+Carhuas Romero Erick Jesus
+David Alonso Olano Huerta


### PR DESCRIPTION
Se añade el archivo `Integrantes.txt` que contiene los nombres completos de los integrantes del grupo, como parte del laboratorio de Introducción a Git y GitHub.

Este cambio forma parte del flujo de trabajo solicitado en la guía:
- Se creó una rama de desarrollo.
- Se agregó el archivo.
- Se realizó el commit y el push correctamente.

Solicito la revisión y fusión de esta pull request hacia la rama principal (main).